### PR TITLE
Double checks to ensure best model is refit on all train data

### DIFF
--- a/neuropredict/config_neuropredict.py
+++ b/neuropredict/config_neuropredict.py
@@ -83,6 +83,10 @@ INNER_CV_TEST_PERC = 0.2
 INNER_CV_NUM_FOLDS = 5
 INNER_CV_NUM_REPEATS = 5
 
+# although refit is True by default in GridSearchCV, this is to avoid depending on
+# defaults for future releases!
+refit_best_model_on_ALL_training_set = True
+
 # parallelization is now achieved at the repetitions level.
 DEFAULT_NUM_PROCS = 4
 GRIDSEARCH_PRE_DISPATCH = 1

--- a/neuropredict/rhst.py
+++ b/neuropredict/rhst.py
@@ -178,7 +178,8 @@ def optimize_pipeline_via_grid_search_CV(pipeline, train_data_mat, train_labels,
 
     # not specifying n_jobs to avoid any kind of parallelism (joblib) from within sklearn
     # to avoid potentially bad interactions with outer parallization with builtin multiprocessing library
-    gs = GridSearchCV(estimator=pipeline, param_grid=param_grid, cv=inner_cv)
+    gs = GridSearchCV(estimator=pipeline, param_grid=param_grid, cv=inner_cv,
+                      refit=cfg.refit_best_model_on_ALL_training_set)
 
     # ignoring some not-so-critical warnings
     with warnings.catch_warnings():

--- a/neuropredict/run_workflow.py
+++ b/neuropredict/run_workflow.py
@@ -578,6 +578,11 @@ def make_visualizations(results_file_path, out_dir, options_path=None):
     num_times_misclfd       = results_dict['num_times_misclfd']
     num_times_tested        = results_dict['num_times_tested']
 
+    num_methods = len(method_names)
+    if len(set(method_names)) < num_methods:
+        method_names = ['m{}_{}'.format(ix,mn)
+                        for ix, mn in enumerate(method_names)]
+
     feature_importances_available = True
     if options_path is not None:
         user_options = load_options(out_dir, options_path)


### PR DESCRIPTION
That was already the case in `GridSearchCV`, but doubly enforcing it now.